### PR TITLE
Added type checks to emitEvent

### DIFF
--- a/FuckFuckAdBlock.user.js
+++ b/FuckFuckAdBlock.user.js
@@ -70,12 +70,8 @@
         emitEvent : function(detected) {
             if(detected === false) {
                 var fns = this._var.triggers;
-                if (fns) {
-                    for (i in fns) {
-                        if (fns.hasOwnProperty(i) && fns[i] instanceof Function) {
-                            fns[i]();
-                        }
-                    }
+                for (var i = 0; i < fns.length; i += 1) {
+                    if (fns[i] instanceof Function) { fns[i](); }
                 }
                 if(this._options.resetOnEnd === true)
                     this.clearEvent();

--- a/FuckFuckAdBlock.user.js
+++ b/FuckFuckAdBlock.user.js
@@ -70,9 +70,13 @@
         emitEvent : function(detected) {
             if(detected === false) {
                 var fns = this._var.triggers;
-                for(i in fns)
-                    fns[i]();
-
+                if (fns) {
+                    for (i in fns) {
+                        if (fns.hasOwnProperty(i) && fns[i] instanceof Function) {
+                            fns[i]();
+                        }
+                    }
+                }
                 if(this._options.resetOnEnd === true)
                     this.clearEvent();
             }


### PR DESCRIPTION
After load, FAB will emit the `detected` event with the argument `false`.  To do this, it iterates over an array of registered listeners, called `fns`.  It does this iteration using (for whatever reason) object iteration (e.g., `for (x in y)`).  On any page where the Array prototype has been extended, this will capture all prototype extensions that have not been marked as non-enumerable.  Indeed, the first thing it did when I loaded up the web application I'm presently working on was fail.

I've added type checking to avoid this being a problem (naive make-it-work-without refactoring).

The intermediate commit demonstrates the type checking that needs to be done to safely use object iteration over an array.  The final commit uses the correct way to iterate over arrays.
